### PR TITLE
fix: temp disable lookaheads

### DIFF
--- a/benchmark/aoc2023-day12-result.txt
+++ b/benchmark/aoc2023-day12-result.txt
@@ -1,3 +1,3 @@
 
-  Part 1: 7191 (time: 973ms)
-  Part 2: 6512849198636 (time: 11618ms) 
+  Part 1: 7191 (time: 1048ms)
+  Part 2: 6512849198636 (time: 11977ms) 

--- a/benchmark/parser-bench-result.txt
+++ b/benchmark/parser-bench-result.txt
@@ -1,5 +1,5 @@
 
-  error ratio      : 17 / 749
-  total parse time : 5908ms
-  avg parse time   : 8.07103825136612ms
-  max parse time   : 919ms
+  error ratio      : 10 / 749
+  total parse time : 5663ms
+  avg parse time   : 7.663058186738836ms
+  max parse time   : 849ms

--- a/benchmark/toStdRegex_output_length-result.txt
+++ b/benchmark/toStdRegex_output_length-result.txt
@@ -1,17 +1,17 @@
 
 failed instances:
-- parseError         : 49
-- cacheOverflow      : 89
-- veryLargeSyntaTree : 24
+- parseError         : 111
+- cacheOverflow      : 80
+- veryLargeSyntaTree : 23
 - stackOverflow      : 12
 - regexSyntaxError   : 0
 
 size multipliers:
-- mean   : 321.86932736154387
-- median : 1.1923076923076923
+- mean   : 330.0766901004811
+- median : 1.6666666666666667
 - max    : 178441.75438596492
 - min    : 0.0021570319240724763
 
 memory:
-- max heap used : 2491.6993865966797 MB
-- max rss       : 2909.78515625 MB
+- max heap used : 2354.146553039551 MB
+- max rss       : 2755.58203125 MB

--- a/equiv-checker.html
+++ b/equiv-checker.html
@@ -363,7 +363,6 @@
         <li>Character classes: <code>.</code>, <code>\w</code>, <code>[a-zA-Z]</code>, ...</li>
         <li>Escaping: <code>\$</code>, <code>\.</code>, ...</li>
         <li>(Non-)capturing groups: <code>(?...)</code>, <code>(...)</code></li>
-        <li>Positive/negative lookahead: <code>(?=...)</code>, <code>(?!...)</code></li>
       </ul>
 
       <h4>Unsupported syntax:</h4>
@@ -372,7 +371,8 @@
         <li>Local flags: <code>(?i:...)</code>, ...</li>
         <li>Unicode property escapes: <code>\p{...}</code>, <code>\P{...}</code></li>
         <li>Backreferences: <code>\1</code>, <code>\2</code>, ...</li>
-        <li>Lookbehind assertions: <code>(?&lt;=...)</code>, <code>(?&lt;!...)</code></li>
+        <li>Positive/negative lookahead: <code>(?=...)</code>, <code>(?!...)</code></li>
+        <li>Positive/negative lookbehind assertions: <code>(?&lt;=...)</code>, <code>(?&lt;!...)</code></li>
         <li>Word boundary: <code>\b</code>, <code>\B</code></li>
       </ul>
 
@@ -407,10 +407,10 @@
         const urlParams = new URLSearchParams(window.location.search);
         const regex1 = urlParams.get('regexp1');
         const regex2 = urlParams.get('regexp2');
-        
+
         if (regex1) regex1Input.value = regex1;
         if (regex2) regex2Input.value = regex2;
-        
+
         // Auto-check equivalence if both parameters are present
         if (regex1 && regex2) {
           setTimeout(checkEquivalence, 100);
@@ -422,14 +422,14 @@
         const urlParams = new URLSearchParams();
         const regex1 = regex1Input.value.trim();
         const regex2 = regex2Input.value.trim();
-        
+
         if (regex1) urlParams.set('regexp1', regex1);
         if (regex2) urlParams.set('regexp2', regex2);
-        
-        const newURL = urlParams.toString() ? 
-          `${window.location.pathname}?${urlParams.toString()}` : 
+
+        const newURL = urlParams.toString() ?
+          `${window.location.pathname}?${urlParams.toString()}` :
           window.location.pathname;
-        
+
         window.history.replaceState(null, '', newURL);
       }
 
@@ -474,9 +474,9 @@
         const hasEndAnchor1 = pattern1.includes('$');
         const hasStartAnchor2 = pattern2.includes('^');
         const hasEndAnchor2 = pattern2.includes('$');
-        
+
         const shouldShowAnchorInfo = !hasStartAnchor1 || !hasEndAnchor1 || !hasStartAnchor2 || !hasEndAnchor2;
-        
+
         // Show/hide anchor info banner
         if (shouldShowAnchorInfo) {
           anchorInfoBanner.style.display = 'block';
@@ -516,7 +516,7 @@
             const hasValidationIssue = !(
               stringsMatchingAButNotB.every(str => regexA.test(str) && !regexB.test(str)) &&
               stringsMatchingBButNotA.every(str => regexB.test(str) && !regexA.test(str))
-            );           
+            );
             const examples = {
               regex1Only: stringsMatchingAButNotB.length > 0 ? stringsMatchingAButNotB : null,
               regex2Only: stringsMatchingBButNotA.length > 0 ? stringsMatchingBButNotA : null
@@ -574,12 +574,12 @@
 
         // Build the complete HTML structure
         let html = '';
-        
+
         // Add warning banner if there's a validation issue
         if (hasValidationIssue) {
           html += '<div class="mismatch-warning">Something went wrong. The presented example strings don\'t match the regex as claimed. Please file an issue on GitHub with your input regex.</div>';
         }
-        
+
         html += message;
 
         // Add Venn diagram (only for subset/superset/not-equivalent cases)
@@ -591,7 +591,7 @@
         if (examples) {
           html += '<p>Example strings matched by one RegExp but not the other:</p>'
           html += '<div style="display: flex; gap: 20px; margin-top: 15px;">';
-          
+
           // Left column for RegExp 1 examples
           html += '<div style="flex: 1;">';
           if (examples.regex1Only && examples.regex1Only.length > 0) {
@@ -601,7 +601,7 @@
             </p>`;
           }
           html += '</div>';
-          
+
           // Right column for RegExp 2 examples
           html += '<div style="flex: 1;">';
           if (examples.regex2Only && examples.regex2Only.length > 0) {
@@ -611,7 +611,7 @@
             </p>`;
           }
           html += '</div>';
-          
+
           html += '</div>';
         }
 

--- a/test/ast.spec.ts
+++ b/test/ast.spec.ts
@@ -23,7 +23,7 @@ describe('toExtRegex', () => {
   describe('union with empty members', () => {
     const testCases = [
       [/^(|a)$/, RE.optional(RE.singleChar('a'))],
-      [/^(a||)$/, RE.optional(RE.singleChar('a'), )],
+      [/^(a||)$/, RE.optional(RE.singleChar('a'),)],
       [/^(|a|)$/, RE.optional(RE.singleChar('a'))],
       [/^(|)$/, RE.epsilon],
     ] as const
@@ -61,15 +61,16 @@ describe('toExtRegex', () => {
       [/(a?)$^(b*)/, RE.epsilon],
 
       // Contradiction inside lookahead collapses to empty set. Then empty set lookahead can't match anything:
-      [/(?=a^)/, RE.empty],
+      // FIXME:
+      // [/(?=a^)/, RE.empty],
 
       [/(^a|)^b/, RE.seq([RE.singleChar('b'), dotStar])],
-      [/^a(b^|c)/, RE.seq([RE.string('ac'), dotStar]) ],
+      [/^a(b^|c)/, RE.seq([RE.string('ac'), dotStar])],
       [/(^|a)b/, prefix(RE.concat(RE.optional(suffix(RE.singleChar('a'))), RE.singleChar('b')))],
 
       // FIXME:
       // [/(^)+a$/, RE.singleChar('a') ],
-      [/(^)*a$/, suffix(RE.singleChar('a')) ],
+      [/(^)*a$/, suffix(RE.singleChar('a'))],
       [/(b|^)a$/, RE.concat(RE.optional(suffix(RE.singleChar('b'))), RE.singleChar('a'))],
       [/a(^)/, RE.empty],
     ] as const
@@ -82,35 +83,36 @@ describe('toExtRegex', () => {
     }
   })
 
-  describe('lookahead elimination', () => {
-    const testCases = [
-      // positive lookahead:
-      [/^(?=a)a$/, RE.string('a')],
-      [/^a(?=b)b$/, RE.string('ab')],
-      [/^((?=a)a|(?=b)b)$/, RE.union(RE.string('a'), RE.string('b'))],
-      [/^(?=[0-5])(?=[5-9])[3-7]$/, RE.string('5')],
-      // negative lookahead:
-      [/^a(?!b)c$/, RE.concat(RE.string('a'), RE.intersection(RE.complement(RE.string('b')), RE.string('c')))],
-      // TODO: lookahead + lookbehind
-      // [/^a(?=b)(?<=a)b$/, RE.string('ab')],
-      // [/^b(?=ab)a(?<=ba)b$/, RE.string('bab')],
-      // [/^a(?=b)(?<=a)(?!a)(?<!b)b$/, RE.string('ab')],
-    ] as const
+  // FIXME:
+  // describe('lookahead elimination', () => {
+  //   const testCases = [
+  //     // positive lookahead:
+  //     [/^(?=a)a$/, RE.string('a')],
+  //     [/^a(?=b)b$/, RE.string('ab')],
+  //     [/^((?=a)a|(?=b)b)$/, RE.union(RE.string('a'), RE.string('b'))],
+  //     [/^(?=[0-5])(?=[5-9])[3-7]$/, RE.string('5')],
+  //     // negative lookahead:
+  //     [/^a(?!b)c$/, RE.concat(RE.string('a'), RE.intersection(RE.complement(RE.string('b')), RE.string('c')))],
+  //     // TODO: lookahead + lookbehind
+  //     // [/^a(?=b)(?<=a)b$/, RE.string('ab')],
+  //     // [/^b(?=ab)a(?<=ba)b$/, RE.string('bab')],
+  //     // [/^a(?=b)(?<=a)(?!a)(?<!b)b$/, RE.string('ab')],
+  //   ] as const
 
-    for (const [regexp, expected] of testCases) {
-      it(`${regexp}`, () => {
-        const actual = AST.toExtRegex(parseRegExp(regexp))
-        assert.equal(actual.hash, expected.hash, RE.debugShow(actual) + '\n\n' + RE.debugShow(expected))
-      })
-    }
+  //   for (const [regexp, expected] of testCases) {
+  //     it(`${regexp}`, () => {
+  //       const actual = AST.toExtRegex(parseRegExp(regexp))
+  //       assert.equal(actual.hash, expected.hash, RE.debugShow(actual) + '\n\n' + RE.debugShow(expected))
+  //     })
+  //   }
 
-    it('fixme', { todo: true }, () => {
-      const actual = AST.toExtRegex(parseRegExp(/^(a(?!b))*$/))
-      const expected = RE.star(RE.string('a'))
-      assert.equal(actual.hash, expected.hash)
-    })
+  //   it('fixme', { todo: true }, () => {
+  //     const actual = AST.toExtRegex(parseRegExp(/^(a(?!b))*$/))
+  //     const expected = RE.star(RE.string('a'))
+  //     assert.equal(actual.hash, expected.hash)
+  //   })
 
-  })
+  // })
 
 })
 
@@ -119,16 +121,16 @@ describe('toString', () => {
   const testCases = [
     [AST.repeat(AST.string('a'), { min: 0, max: 3 }), /a{0,3}/],
     // If `min` is `undefined` it must still explicitly be set to zero
-    // because `a{,3}` is interpreted as the literal string "a{,3}" in 
+    // because `a{,3}` is interpreted as the literal string "a{,3}" in
     // the JavaScript regex flavor:
     [AST.repeat(AST.string('a'), { max: 3 }), /a{0,3}/],
   ] as const
 
   for (const [inputAST, expected] of testCases) {
-    it(`${expected}`, { only: true }, () => {
+    it(`${expected}`, () => {
       const str = AST.toString(inputAST, { useNonCapturingGroups: false })
       assert.equal(str, expected.source)
     })
   }
-  
+
 })


### PR DESCRIPTION
Lookahead assertions are broken in many ways. Now throwing UnsupportedSyntaxError for expressions that contain them.

Refs: #13